### PR TITLE
Change the default value of onoff_dots so that the grid is turned off at startup

### DIFF
--- a/res/main.qml
+++ b/res/main.qml
@@ -81,7 +81,7 @@ Window {
     property string time
     property bool was_AM
     property bool was_special: false
-    property int onoff_dots: 4
+    property int onoff_dots: 0
     property int previous_hours_array_index: -1
     property int hours_array_index: 0
     readonly property int hours_array_step: 1


### PR DESCRIPTION
# Kind reminder
Please review this pull request code with kindness, care, and sympathy
I will remain open to any criticism and will be happy to improve my pull request from your remarks

# Description

The onoff_dots value does not need to be set to 4 at startup, and setting it to zero allows the grill to be turned off.

## Type of change

- [x] Update hard-coded values

# How Has This Been Tested?

- Launch the app once.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
